### PR TITLE
Lock lvl11

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Il vous faut un gestionnaire d'userscripts. C'est une extension de navigateur. L
 * Tampermonkey pour Chrome/Chromium (testé)
 * NinjaKit pour Safari (**non** testé)
 
-*Nota Bene:* habituellement, mon cycle de test est le suivant : je développe sous Firefox/Greasemonkey, puis teste sous Chrome/Tampermonkey, toutes versions à jour. Je fais mon possible pour éviter de laisser des bugs sous Chrome, mais il arrivent que certains passent entre les mailles du filet. Quant aux autres navigateurs, je ne peux pas y garantir la compatibilité de mon script,
+*Nota Bene:* habituellement, mon cycle de test est le suivant : je développe sous Firefox/Greasemonkey, puis teste sous Chrome/Tampermonkey, toutes versions à jour. Je fais mon possible pour éviter de laisser des bugs sous Chrome, mais il arrive que certains passent entre les mailles du filet. Quant aux autres navigateurs, je ne peux pas y garantir la compatibilité de mon script,
 
 Une fois votre gestionnaire d'userscripts installé, cliquez simplement sur le lien du script : [dinorpg-assistant.user.js](https://github.com/Watilin/DinoRPG-Assistant/raw/master/dinorpg-assistant.user.js). Votre gestionnaire vous demandera l'autorisation d'installer le script. L'installation est automatique.
 

--- a/README.md
+++ b/README.md
@@ -1,26 +1,34 @@
 # DinoRPG-Assistant
 
-Diverses petites améliorations pour le jeu DinoRPG:
+Diverses petites améliorations pour le jeu DinoRPG :
 
 * Un décompte du temps avant nouvelle action pour chaque dinoz ;
 * Les niveaux indiqués à côté de chaque dinoz ;
-* Un système de verrouillage pour les dinoz qui ne doivent pas monter de niveau.
+* Un système de « marquage » pour les dinoz qui ne doivent pas monter de niveau (détails à ce propos plus bas).
 
 ## Comment on s'en sert ?
 
 Il vous faut un gestionnaire d'userscripts. C'est une extension de navigateur. Les plus connus sont :
 
-* Greasemonkey pour Firefox
-* Tampermonkey pour Chrome/Chromium
-* NinjaKit pour Safari 
+* Greasemonkey pour Firefox (testé)
+* Tampermonkey pour Chrome/Chromium (testé)
+* NinjaKit pour Safari (**non** testé)
 
-*Nota Bene:* j'ai développé et testé la version 1 avec Greasemonkey uniquement. Je ne garantis pas la compatibilité de mon script avec d'autres logiciels.
+*Nota Bene:* habituellement, mon cycle de test est le suivant : je développe sous Firefox/Greasemonkey, puis teste sous Chrome/Tampermonkey, toutes versions à jour. Je fais mon possible pour éviter de laisser des bugs sous Chrome, mais il arrivent que certains passent entre les mailles du filet. Quant aux autres navigateurs, je ne peux pas y garantir la compatibilité de mon script,
 
 Une fois votre gestionnaire d'userscripts installé, cliquez simplement sur le lien du script : [dinorpg-assistant.user.js](https://github.com/Watilin/DinoRPG-Assistant/raw/master/dinorpg-assistant.user.js). Votre gestionnaire vous demandera l'autorisation d'installer le script. L'installation est automatique.
 
 ## Vos données privées
 
 Ce script ne vole pas vos données ;) Il ne fait pas de requêtes ni vers les serveurs de DinoRPG ni vers un serveur tiers. Les données sont stockées en local sur votre machine, et sont automatiquement supprimées si vous désinstallez le script.
+
+## Les « dinoz qui ne doivent pas monter de niveau »… ?
+
+Ce script ne permet pas de faire faire des actions à un dinoz de niveau inférieur à 11 quand il est prêt à passer au niveau supérieur, conformément à la charte du jeu.
+
+La fonctionnalité de « marquage » n’est active que sur les dinoz de niveau 11 et plus ; d’autre part, il s’agit principalement d’une indication visuelle (les images « level up » sont grisées et ne clignotent plus), et le bouton de level up est désactivé dans le seul but d’empêcher le joueur de cliquer dessus accidentellement.
+
+Bien entendu, seuls les dinoz que le joueur a choisi de marquer sont « protégés », les autres dinoz peuvent continuer à monter de niveau normalement.
 
 ## Désinstaller le script
 

--- a/dinorpg-assistant.meta.js
+++ b/dinorpg-assistant.meta.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name        DinoRPG Assistant
 // @namespace   fr.kergoz-panic.watilin
-// @version     1.1.0
+// @version     1.1.1
 // @description Diverses petites améliorations pour le jeu DinoRPG.
 // @author      Watilin
 // @licence     GNU/GPL 2.0

--- a/dinorpg-assistant.user.js
+++ b/dinorpg-assistant.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name        DinoRPG Assistant
 // @namespace   fr.kergoz-panic.watilin
-// @version     1.1.0
+// @version     1.1.1
 // @description Diverses petites améliorations pour le jeu DinoRPG.
 // @author      Watilin
 // @licence     GNU/GPL 2.0
@@ -234,10 +234,13 @@ function injectLevels($list) {
 // [@LOC] Lock /////////////////////////////////////////////////////////
 
 function injectLockButton($actionsPanel, dinoId) {
+  var info = GM_getValue(dinoId, {});
+  if (!(info && info.level && info.level > 10)) return;
+
   var $button = document.createElement("a");
   $button.href = "#";
   $button.classList.add("button", "lock-button");
-  $button.textContent = GM_getValue(dinoId, {}).isLocked ?
+  $button.textContent = info.isLocked ?
     UNLOCK_TXT : LOCK_TXT;
 
   $button.addEventListener("click", function (event) {


### PR DESCRIPTION
Corrige un oubli par rapport au précédent TODO dans le changelog, à propos du verrouillage devant être possible seulement à partir du niveau 11 du dinoz. Le TODO a été marqué comme résolu, mais en réalité ne l’était pas.
